### PR TITLE
changed axios url to deployed heroku site

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,11 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { Provider } from 'react-redux'
 import configureStore from './state/store/configureStore'
-
 import axios from "axios";
-axios.defaults.baseURL = "http://localhost:3000/api/";
+
+// axios.defaults.baseURL = "http://localhost:3000/api/";
+axios.defaults.baseURL = "https://urban-living.herokuapp.com/api/";
+
 
 const store = configureStore();
 window.store = store;


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171948993)
```
As a developer team
In order to demo our app to our client
We would like that our Front-end link matches the deployed API app.
```
## Changes proposed in this pull request:
* Changed Axios baseURL
## What I have learned working on this feature:
* Deploy early and often