### PR TITLE
Journalist can add images to article 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ const App = props => {
   useEffect(() => {
     navigator.geolocation.getCurrentPosition(async pos => {
       const currentSession = await axios.post(
-        "http://localhost:3000/api/sessions",
+        "https://urban-living.herokuapp.com/api/sessions",
         {
           location: {
             latitude: pos.coords.latitude,

--- a/src/components/ArticleList.jsx
+++ b/src/components/ArticleList.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Box, Grommet, Button } from "grommet";
+import { Box, Grommet, Button, Image } from "grommet";
 import { grommet } from "grommet/themes";
 import axios from "axios";
 import { connect } from "react-redux";
@@ -9,12 +9,13 @@ class ArticleList extends Component {
     axios.get("/articles").then(response => {
       this.props.dispatch({
         type: "ARTICLES",
-        payload: { articleList: response.data.articles }
+        payload: { articleList: response.data }
       });
+
     });
   }
 
-  async articleFetcher (event) {
+  async articleFetcher(event) {
     let id = event.target.dataset.id
     let response = await axios.get(`/articles/${id}`)
     this.props.dispatch({
@@ -37,10 +38,12 @@ class ArticleList extends Component {
             key={article.id}
           >
             <div id={article.id} className="article-box">
+              <div className="article-box">
+                <Image src={article.image}></Image>
+              </div>
               <div className="feature-article">
                 <div className="article-headline">
                   <h2>{article.title}</h2>
-
                   <div className="article-teaser">
                     <p>{article.teaser}</p>
                   </div>

--- a/src/components/ArticleList.jsx
+++ b/src/components/ArticleList.jsx
@@ -11,7 +11,6 @@ class ArticleList extends Component {
         type: "ARTICLES",
         payload: { articleList: response.data }
       });
-
     });
   }
 

--- a/src/components/SpecificArticle.jsx
+++ b/src/components/SpecificArticle.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Box, Grommet, Button } from "grommet";
+import { Box, Grommet, Button, Image } from "grommet";
 import { grommet } from "grommet/themes";
 
 class SpecificArticle extends Component {
@@ -44,25 +44,25 @@ class SpecificArticle extends Component {
           </div>
         </>
       ) : (
-        <>
-          <div className="spec-content restricted">
-            <p>{articleContent}</p>
-          </div>
-          <p>
-            This article require a premium membership.{" "}
-            <Button
-              label="Buy Subscription"
-              color="lightgreen"
-              onClick={() =>
-                this.props.dispatch({
-                  type: "PAYMENT_FORM",
-                  payload: { showPaymentForm: true }
-                })
-              }
-            />
-          </p>
-        </>
-      );
+          <>
+            <div className="spec-content restricted">
+              <p>{articleContent}</p>
+            </div>
+            <p>
+              This article require a premium membership.{" "}
+              <Button
+                label="Buy Subscription"
+                color="lightgreen"
+                onClick={() =>
+                  this.props.dispatch({
+                    type: "PAYMENT_FORM",
+                    payload: { showPaymentForm: true }
+                  })
+                }
+              />
+            </p>
+          </>
+        );
 
     return (
       <Grommet full theme={grommet}>
@@ -75,6 +75,9 @@ class SpecificArticle extends Component {
           id={specArticle.id}
         >
           <div>
+            <div className="spec-image">
+              <Image src={specArticle.image}></Image>
+            </div>
             <div className="spec-title">
               <h2>{specArticle.title}</h2>
             </div>


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171811178)
Co-authored-by: hunter <hmvitous@yahoo.com>
Co-authored-by: karro <karolina.frostare@gmail.com>
Co-authored-by: anish <anish.kanswal@gmail.com>
The above co-authors where also present for the API side of the same feature.

## User Story
```
As a journalist
In order to make my articles more visually appealing
I would like to be able to upload and display images to my articles
```
## Changes proposed in this pull request:
* Imports image feature from Grommit to ArticleList for the displaying images to visitors
* Imports image feature from Grommit to SpecificArticle jsx for the displaying images to visitors
## What I have learned working on this feature:
* Refreshed knowledge on importing from API
## Screenshots (Only if client side story)
![image (1)](https://user-images.githubusercontent.com/59605858/78470273-76938d00-7728-11ea-87a1-7752e913487f.png)
